### PR TITLE
Upgrade ktlint 0.44

### DIFF
--- a/plugin/gradle/libs.versions.toml
+++ b/plugin/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.5.31"
-ktlint = "0.43.2"
+ktlint = "0.44.0"
 androidPlugin = "4.1.0"
 semver = "1.1.1"
 jgit = "5.6.0.201912101111-r"

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -35,7 +35,7 @@ internal constructor(
     /**
      * The version of KtLint to use.
      */
-    val version: Property<String> = objectFactory.property { set("0.43.2") }
+    val version: Property<String> = objectFactory.property { set("0.44.0") }
 
     /**
      * Enable relative paths in reports

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
@@ -112,6 +112,7 @@ class KtLintSupportedVersionsTest : AbstractPluginTest() {
             // "0.43.0" does not work on JDK1.8
             // "0.43.1" asked not to use it
             "0.43.2",
+            "0.44.0",
         ).also {
             // "0.37.0" is failing on Windows machines that is fixed in the next version
             if (!OS.WINDOWS.isCurrentOs) it.add("0.37.0")

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBaselineSupportTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBaselineSupportTest.kt
@@ -49,20 +49,19 @@ class KtlintBaselineSupportTest : AbstractPluginTest() {
                 assertThat(task(":${GenerateBaselineTask.NAME}")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
                 val baselineFile = projectPath.defaultBaselineFile
                 assertThat(baselineFile).exists()
-                // WARN: baseline uses tabs for indentation!
                 //language=xml
                 assertThat(baselineFile.readText()).isEqualToNormalizingNewlines(
                     """
                     |<?xml version="1.0" encoding="utf-8"?>
                     |<baseline version="1.0">
-                    |	<file name="kotlin-script-fail.kts">
-                    |		<error line="1" column="15" source="no-trailing-spaces" />
-                    |	</file>
-                    |	<file name="src/main/kotlin/fail-source.kt">
-                    |		<error line="1" column="5" source="no-multi-spaces" />
-                    |		<error line="1" column="10" source="no-multi-spaces" />
-                    |		<error line="1" column="15" source="no-multi-spaces" />
-                    |	</file>
+                    |    <file name="kotlin-script-fail.kts">
+                    |        <error line="1" column="15" source="no-trailing-spaces" />
+                    |    </file>
+                    |    <file name="src/main/kotlin/fail-source.kt">
+                    |        <error line="1" column="5" source="no-multi-spaces" />
+                    |        <error line="1" column="10" source="no-multi-spaces" />
+                    |        <error line="1" column="15" source="no-multi-spaces" />
+                    |    </file>
                     |</baseline>
                     |
                     """.trimMargin()

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -588,7 +588,7 @@ class KtlintPluginTest : AbstractPluginTest() {
             )
 
             build(":dependencies", "--configuration", KTLINT_RULESET_CONFIGURATION_NAME) {
-                assertThat(output).contains("com.pinterest.ktlint:ktlint-core:0.34.2 -> 0.43.2")
+                assertThat(output).contains("com.pinterest.ktlint:ktlint-core:0.34.2 -> 0.44.0")
             }
         }
     }
@@ -610,7 +610,7 @@ class KtlintPluginTest : AbstractPluginTest() {
             )
 
             build(":dependencies", "--configuration", KTLINT_REPORTER_CONFIGURATION_NAME) {
-                assertThat(output).contains("com.pinterest.ktlint:ktlint-core:0.34.2 -> 0.43.2")
+                assertThat(output).contains("com.pinterest.ktlint:ktlint-core:0.34.2 -> 0.44.0")
             }
         }
     }


### PR DESCRIPTION
ktlint has been updated to 0.44.0 .
There are almost no changes to the ktlint API, so this is only a minor modification.