### PR TITLE
Upgrade ktlint 0.45

### DIFF
--- a/plugin/gradle/libs.versions.toml
+++ b/plugin/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.5.31"
-ktlint = "0.44.0"
+ktlint = "0.45.2"
 androidPlugin = "4.1.0"
 semver = "1.1.1"
 jgit = "5.6.0.201912101111-r"

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/KtlintExtension.kt
@@ -35,7 +35,7 @@ internal constructor(
     /**
      * The version of KtLint to use.
      */
-    val version: Property<String> = objectFactory.property { set("0.44.0") }
+    val version: Property<String> = objectFactory.property { set("0.45.2") }
 
     /**
      * Enable relative paths in reports

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -125,9 +125,9 @@ internal fun Logger.logKtLintDebugMessage(
 }
 
 internal fun checkMinimalSupportedKtLintVersion(ktLintVersion: String) {
-    if (SemVer.parse(ktLintVersion) < SemVer(0, 34, 0)) {
+    if (SemVer.parse(ktLintVersion) < SemVer(0, 45, 0)) {
         throw GradleException(
-            "KtLint versions less than 0.34.0 are not supported. " +
+            "KtLint versions less than 0.45.0 are not supported. " +
                 "Detected KtLint version: $ktLintVersion."
         )
     }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/PluginUtil.kt
@@ -125,9 +125,9 @@ internal fun Logger.logKtLintDebugMessage(
 }
 
 internal fun checkMinimalSupportedKtLintVersion(ktLintVersion: String) {
-    if (SemVer.parse(ktLintVersion) < SemVer(0, 45, 0)) {
+    if (SemVer.parse(ktLintVersion) < SemVer(0, 45, 1)) {
         throw GradleException(
-            "KtLint versions less than 0.45.0 are not supported. " +
+            "KtLint versions less than 0.45.1 are not supported. " +
                 "Detected KtLint version: $ktLintVersion."
         )
     }

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintClassesSerializer.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/KtLintClassesSerializer.kt
@@ -20,13 +20,13 @@ internal interface KtLintClassesSerializer {
     ): List<LintErrorResult>
 
     fun saveReporterProviders(
-        reporterProviders: List<ReporterProvider>,
+        reporterProviders: List<ReporterProvider<*>>,
         serializedReporterProviders: File
     )
 
     fun loadReporterProviders(
         serializedReporterProviders: File
-    ): List<ReporterProvider>
+    ): List<ReporterProvider<*>>
 
     companion object {
         fun create(ktLintVersion: SemVer): KtLintClassesSerializer =
@@ -66,7 +66,7 @@ private class CurrentKtLintClassesSerializer : KtLintClassesSerializer {
     }
 
     override fun saveReporterProviders(
-        reporterProviders: List<ReporterProvider>,
+        reporterProviders: List<ReporterProvider<*>>,
         serializedReporterProviders: File
     ) = ObjectOutputStream(
         serializedReporterProviders.outputStream().buffered()
@@ -78,11 +78,11 @@ private class CurrentKtLintClassesSerializer : KtLintClassesSerializer {
 
     override fun loadReporterProviders(
         serializedReporterProviders: File
-    ): List<ReporterProvider> = ObjectInputStream(
+    ): List<ReporterProvider<*>> = ObjectInputStream(
         serializedReporterProviders.inputStream().buffered()
     ).use {
         @Suppress("UNCHECKED_CAST")
-        it.readObject() as List<ReporterProvider>
+        it.readObject() as List<ReporterProvider<*>>
     }
 }
 
@@ -118,7 +118,7 @@ private class OldKtLintClassesSerializer : KtLintClassesSerializer {
     }
 
     override fun saveReporterProviders(
-        reporterProviders: List<ReporterProvider>,
+        reporterProviders: List<ReporterProvider<*>>,
         serializedReporterProviders: File
     ) = ObjectOutputStream(
         serializedReporterProviders.outputStream().buffered()
@@ -130,7 +130,7 @@ private class OldKtLintClassesSerializer : KtLintClassesSerializer {
 
     override fun loadReporterProviders(
         serializedReporterProviders: File
-    ): List<ReporterProvider> = ValidatingObjectInputStream(
+    ): List<ReporterProvider<*>> = ValidatingObjectInputStream(
         serializedReporterProviders.inputStream().buffered()
     ).use {
         it.accept(

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/LoadReportersWorkAction.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/LoadReportersWorkAction.kt
@@ -49,7 +49,7 @@ internal abstract class LoadReportersWorkAction : WorkAction<LoadReportersWorkAc
             if (isEmpty()) setOf(ReporterType.PLAIN) else this
         }
 
-    private fun loadAllReporterProviders(): List<ReporterProvider> = ServiceLoader
+    private fun loadAllReporterProviders(): List<ReporterProvider<*>> = ServiceLoader
         .load(ReporterProvider::class.java)
         .toList()
         .also { reporterProviders ->
@@ -61,8 +61,8 @@ internal abstract class LoadReportersWorkAction : WorkAction<LoadReportersWorkAc
         }
 
     private fun filterEnabledBuiltInProviders(
-        allProviders: List<ReporterProvider>
-    ): List<Pair<LoadedReporter, ReporterProvider>> {
+        allProviders: List<ReporterProvider<*>>
+    ): List<Pair<LoadedReporter, ReporterProvider<*>>> {
         val enabledReporters = getEnabledReporters()
 
         val enabledProviders = allProviders
@@ -89,8 +89,8 @@ internal abstract class LoadReportersWorkAction : WorkAction<LoadReportersWorkAc
     }
 
     private fun filterCustomProviders(
-        allProviders: List<ReporterProvider>
-    ): List<Pair<LoadedReporter, ReporterProvider>> {
+        allProviders: List<ReporterProvider<*>>
+    ): List<Pair<LoadedReporter, ReporterProvider<*>>> {
         val customReporters = parameters.customReporters.get()
         val customProviders = allProviders
             .filter { reporterProvider ->

--- a/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/SerializableReporterProvider.kt
+++ b/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/worker/SerializableReporterProvider.kt
@@ -13,10 +13,10 @@ import kotlin.reflect.jvm.jvmName
  * Should be removed once KtLint will add interface implementation into [ReporterProvider].
  */
 internal class SerializableReporterProvider(
-    reporterProvider: ReporterProvider
+    reporterProvider: ReporterProvider<*>
 ) : Serializable {
     @Transient
-    var reporterProvider: ReporterProvider = reporterProvider
+    var reporterProvider: ReporterProvider<*> = reporterProvider
         private set
 
     @Throws(IOException::class)
@@ -29,7 +29,7 @@ internal class SerializableReporterProvider(
         val reporterProviderClassName = oin.readUTF()
         val classLoader = this.javaClass.classLoader
         val reporterProviderClass = classLoader.loadClass(reporterProviderClassName)
-        reporterProvider = reporterProviderClass.newInstance() as ReporterProvider
+        reporterProvider = reporterProviderClass.newInstance() as ReporterProvider<*>
     }
 
     companion object {

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/DisabledRulesTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/DisabledRulesTest.kt
@@ -95,28 +95,4 @@ class DisabledRulesTest : AbstractPluginTest() {
             }
         }
     }
-
-    @DisplayName("Should fail if KtLint version is lower then 0.34.2 and disabled rules configuration is set")
-    @CommonTest
-    fun lintShouldFailOnUnsupportedVersion(gradleVersion: GradleVersion) {
-        project(gradleVersion) {
-            //language=Groovy
-            buildGradle.appendText(
-                """
-    
-                ktlint.version = "0.34.0"
-                ktlint.disabledRules = ["final-newline"]
-                """.trimIndent()
-            )
-
-            withCleanSources()
-
-            buildAndFail(CHECK_PARENT_TASK_NAME) {
-                assertThat(
-                    task(":${KtLintCheckTask.buildTaskNameForSourceSet("main")}")?.outcome
-                ).isEqualTo(TaskOutcome.FAILED)
-                assertThat(output).contains("Rules disabling is supported since 0.34.2 ktlint version.")
-            }
-        }
-    }
 }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
@@ -96,30 +96,10 @@ class KtLintSupportedVersionsTest : AbstractPluginTest() {
 
     class SupportedKtlintVersionsProvider : GradleArgumentsProvider() {
         private val supportedKtlintVersions = mutableListOf(
-            "0.34.0",
-            "0.34.2",
-            "0.35.0",
-            "0.36.0",
-            "0.37.1",
-            "0.37.2",
-            // "0.38.0" has been compiled with Kotlin apiLevel 1.4 and not supported by Gradle plugins
-            "0.38.1",
-            "0.39.0",
-            "0.40.0",
-            "0.41.0",
-            "0.42.0",
-            "0.42.1",
-            // "0.43.0" does not work on JDK1.8
-            // "0.43.1" asked not to use it
-            "0.43.2",
-            "0.44.0",
             "0.45.0",
             "0.45.1",
             "0.45.2",
-        ).also {
-            // "0.37.0" is failing on Windows machines that is fixed in the next version
-            if (!OS.WINDOWS.isCurrentOs) it.add("0.37.0")
-        }
+        )
 
         override fun provideArguments(
             context: ExtensionContext

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
@@ -96,7 +96,6 @@ class KtLintSupportedVersionsTest : AbstractPluginTest() {
 
     class SupportedKtlintVersionsProvider : GradleArgumentsProvider() {
         private val supportedKtlintVersions = mutableListOf(
-            "0.45.0",
             "0.45.1",
             "0.45.2",
         )

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtLintSupportedVersionsTest.kt
@@ -113,6 +113,9 @@ class KtLintSupportedVersionsTest : AbstractPluginTest() {
             // "0.43.1" asked not to use it
             "0.43.2",
             "0.44.0",
+            "0.45.0",
+            "0.45.1",
+            "0.45.2",
         ).also {
             // "0.37.0" is failing on Windows machines that is fixed in the next version
             if (!OS.WINDOWS.isCurrentOs) it.add("0.37.0")

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBaselineSupportTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBaselineSupportTest.kt
@@ -96,29 +96,6 @@ class KtlintBaselineSupportTest : AbstractPluginTest() {
         }
     }
 
-    @DisplayName("Generate baseline task should work only when KtLint version is higher then 0.41.0")
-    @CommonTest
-    fun generateBaselineMinVersion(gradleVersion: GradleVersion) {
-        project(gradleVersion) {
-            withFailingSources()
-
-            //language=Groovy
-            buildGradle.appendText(
-                """
-                
-                ktlint {
-                    version.set("0.40.0")
-                }
-                """.trimIndent()
-            )
-
-            build(GenerateBaselineTask.NAME) {
-                assertThat(task(":${GenerateBaselineTask.NAME}")?.outcome).isEqualTo(TaskOutcome.SKIPPED)
-                assertThat(output).containsSequence("Generate baseline only works starting from KtLint 0.41.0 version")
-            }
-        }
-    }
-
     @DisplayName("Should consider existing issues in baseline")
     @CommonTest
     fun existingIssueFilteredByBaseline(gradleVersion: GradleVersion) {
@@ -142,30 +119,6 @@ class KtlintBaselineSupportTest : AbstractPluginTest() {
             withFailingKotlinScript()
             buildAndFail(CHECK_PARENT_TASK_NAME) {
                 assertThat(task(":$kotlinScriptCheckTaskName")?.outcome).isEqualTo(TaskOutcome.FAILED)
-            }
-        }
-    }
-
-    @DisplayName("Should fail the build if baseline file is present and ktlint version is less then 0.41.0")
-    @CommonTest
-    fun failBuildOnOldKtlintVersionsAndBaselinePresent(gradleVersion: GradleVersion) {
-        project(gradleVersion) {
-            withCleanSources()
-            build(GenerateBaselineTask.NAME)
-
-            //language=Groovy
-            buildGradle.appendText(
-                """
-                
-                ktlint {
-                    version.set("0.40.0")
-                }
-                """.trimIndent()
-            )
-
-            buildAndFail(CHECK_PARENT_TASK_NAME) {
-                assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.FAILED)
-                assertThat(output).contains("Baseline support is only enabled for KtLint versions 0.41.0+.")
             }
         }
     }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBaselineSupportTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintBaselineSupportTest.kt
@@ -56,6 +56,7 @@ class KtlintBaselineSupportTest : AbstractPluginTest() {
                     |<baseline version="1.0">
                     |    <file name="kotlin-script-fail.kts">
                     |        <error line="1" column="15" source="no-trailing-spaces" />
+                    |        <error line="1" column="16" source="no-multi-spaces" />
                     |    </file>
                     |    <file name="src/main/kotlin/fail-source.kt">
                     |        <error line="1" column="5" source="no-multi-spaces" />

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -588,7 +588,7 @@ class KtlintPluginTest : AbstractPluginTest() {
             )
 
             build(":dependencies", "--configuration", KTLINT_RULESET_CONFIGURATION_NAME) {
-                assertThat(output).contains("com.pinterest.ktlint:ktlint-core:0.34.2 -> 0.44.0")
+                assertThat(output).contains("com.pinterest.ktlint:ktlint-core:0.34.2 -> 0.45.2")
             }
         }
     }
@@ -610,7 +610,7 @@ class KtlintPluginTest : AbstractPluginTest() {
             )
 
             build(":dependencies", "--configuration", KTLINT_REPORTER_CONFIGURATION_NAME) {
-                assertThat(output).contains("com.pinterest.ktlint:ktlint-core:0.34.2 -> 0.44.0")
+                assertThat(output).contains("com.pinterest.ktlint:ktlint-core:0.34.2 -> 0.45.2")
             }
         }
     }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -28,7 +28,7 @@ class KtlintPluginTest : AbstractPluginTest() {
 
             buildAndFail(CHECK_PARENT_TASK_NAME) {
                 assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.FAILED)
-                assertThat(output).contains("Unnecessary space(s)")
+                assertThat(output).contains("Unnecessary long whitespace")
             }
         }
     }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginTest.kt
@@ -230,14 +230,14 @@ class KtlintPluginTest : AbstractPluginTest() {
             buildGradle.appendText(
                 """
 
-                ktlint.version = "0.35.0"
+                ktlint.version = "0.45.1"
                 """.trimIndent()
             )
 
             build(":dependencies") {
                 assertThat(output).contains(
                     "$KTLINT_CONFIGURATION_NAME - $KTLINT_CONFIGURATION_DESCRIPTION${System.lineSeparator()}" +
-                        "\\--- com.pinterest:ktlint:0.35.0${System.lineSeparator()}"
+                        "\\--- com.pinterest:ktlint:0.45.1${System.lineSeparator()}"
                 )
             }
         }
@@ -398,7 +398,7 @@ class KtlintPluginTest : AbstractPluginTest() {
                 """
 
                 ktlint.enableExperimentalRules = true
-                ktlint.version = "0.34.0"
+                ktlint.version = "0.45.1"
                 """.trimIndent()
             )
 

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginVersionTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/KtlintPluginVersionTest.kt
@@ -28,25 +28,12 @@ class KtlintPluginVersionTest : AbstractPluginTest() {
         )
     }
 
-    @DisplayName("Should allow to use KtLint version 0.34.0")
-    @CommonTest
-    fun allowSupportedMinimalKtLintVersion(gradleVersion: GradleVersion) {
-        project(gradleVersion) {
-            withCleanSources()
-            buildGradle.useKtlintVersion("0.34.0")
-
-            build(CHECK_PARENT_TASK_NAME) {
-                assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-            }
-        }
-    }
-
-    @DisplayName("Should fail the build on using KtLint version <0.34.0")
+    @DisplayName("Should fail the build on using KtLint version <0.45.1")
     @CommonTest
     fun failOnUnsupportedOldKtLintVersion(gradleVersion: GradleVersion) {
         project(gradleVersion) {
             withCleanSources()
-            buildGradle.useKtlintVersion("0.33.0")
+            buildGradle.useKtlintVersion("0.45.0")
             buildAndFail(CHECK_PARENT_TASK_NAME) {
                 assertThat(task(":${LoadReportersTask.TASK_NAME}")?.outcome).isEqualTo(TaskOutcome.FAILED)
             }

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ReportersTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ReportersTest.kt
@@ -208,31 +208,6 @@ class ReportersTest : AbstractPluginTest() {
         }
     }
 
-    @DisplayName("Should ignore html reporter on KtLint versions less then 0.36.0")
-    @CommonTest
-    @DisabledOnOs(OS.WINDOWS)
-    internal fun ignoreHtmlOnOldVersions(gradleVersion: GradleVersion) {
-        project(gradleVersion) {
-            withCleanSources()
-
-            //language=Groovy
-            buildGradle.appendText(
-                """
-
-                ktlint.version = "0.35.0"
-                ktlint.reporters {
-                    reporter "html"
-                }
-                """.trimIndent()
-            )
-
-            build(CHECK_PARENT_TASK_NAME) {
-                assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-                assertReportNotCreated(ReporterType.HTML.fileExtension, mainSourceSetCheckTaskName)
-            }
-        }
-    }
-
     @DisplayName("Should allow to set custom location for generated reports")
     @CommonTest
     internal fun customReportsLocation(gradleVersion: GradleVersion) {

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ReportersTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/ReportersTest.kt
@@ -35,7 +35,7 @@ class ReportersTest : AbstractPluginTest() {
 
             buildAndFail(CHECK_PARENT_TASK_NAME) {
                 assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.FAILED)
-                assertThat(output).contains("Unnecessary space(s)")
+                assertThat(output).contains("Unnecessary long whitespace")
                 assertReportNotCreated(ReporterType.PLAIN.fileExtension, mainSourceSetCheckTaskName)
                 assertReportCreated(ReporterType.CHECKSTYLE.fileExtension, mainSourceSetCheckTaskName)
                 assertReportCreated(ReporterType.JSON.fileExtension, mainSourceSetCheckTaskName)
@@ -72,7 +72,7 @@ class ReportersTest : AbstractPluginTest() {
 
             buildAndFail(CHECK_PARENT_TASK_NAME) {
                 assertThat(task(":$mainSourceSetCheckTaskName")?.outcome).isEqualTo(TaskOutcome.FAILED)
-                assertThat(output).contains("Unnecessary space(s)")
+                assertThat(output).contains("Unnecessary long whitespace")
                 assertReportCreated(ReporterType.CHECKSTYLE.fileExtension, mainSourceSetCheckTaskName)
                 assertReportNotCreated(ReporterType.PLAIN.fileExtension, mainSourceSetCheckTaskName)
                 assertReportNotCreated(ReporterType.JSON.fileExtension, mainSourceSetCheckTaskName)

--- a/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/worker/SerializableReporterProviderTest.kt
+++ b/plugin/src/test/kotlin/org/jlleitschuh/gradle/ktlint/worker/SerializableReporterProviderTest.kt
@@ -32,7 +32,7 @@ internal class SerializableReporterProviderTest {
         }
     }
 
-    private class TestReporterProvider : ReporterProvider {
+    private class TestReporterProvider : ReporterProvider<Reporter> {
         override val id: String = "test-reporter-provider"
 
         override fun get(

--- a/samples/kotlin-reporter-creating/src/main/kotlin/org/jlleitschuh/gradle/ktlint/sample/CsvReporterProvider.kt
+++ b/samples/kotlin-reporter-creating/src/main/kotlin/org/jlleitschuh/gradle/ktlint/sample/CsvReporterProvider.kt
@@ -4,7 +4,7 @@ import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.ReporterProvider
 import java.io.PrintStream
 
-class CsvReporterProvider : ReporterProvider {
+class CsvReporterProvider : ReporterProvider<Reporter> {
     override val id: String = "csv"
 
     override fun get(


### PR DESCRIPTION
ktlint has been updated to 0.45.2.
ReporterProvider signature has changed to ReporterProvider<T : Reporter>, so it is no longer backward-compatible with versions below 0.45.0.
